### PR TITLE
OPS-9711 Add default scrape protocol to allow coturn metrics

### DIFF
--- a/roles/monitoring_bbb/vars/main.yml
+++ b/roles/monitoring_bbb/vars/main.yml
@@ -241,6 +241,7 @@ bbb_prometheus_turn_coturn_exporter_job:
   relabel_configs: "{{ [{'source_labels': ['__meta_ionos_server_name'], 'regex': 'turn-.*', 'action': 'keep'}] + bbb_prometheus_relabel_configs }}"
   scrape_interval: "{{ bbb_monitoring_scrape_interval }}"
   scrape_timeout: "{{ bbb_monitoring_scrape_timeout }}"
+  fallback_scrape_protocol: PrometheusText1.0.0
 
 bbb_prometheus_turn_coturn_cadvisor_job:
   job_name: "{{ bbb_instance_name }}-turn-coturn-cadvisor"


### PR DESCRIPTION
Added "fallback_scrape_protocol: PrometheusText1.0.0" to operator config for coturn