### PR TITLE
refactor(kubernetes_roles): Create subtask and serviceaccount creation

### DIFF
--- a/roles/kubernetes_roles/README.md
+++ b/roles/kubernetes_roles/README.md
@@ -1,0 +1,102 @@
+# kubernetes_roles
+
+Manages Kubernetes RBAC (roles, role bindings, service accounts).
+
+## Subtasks
+
+The role runs in three phases. Each can be toggled independently via a boolean variable (all default to `true`):
+
+| Variable | Task | Description |
+|---|---|---|
+| `update_roles` | `update_roles.yml` | Create/remove ClusterRole resources |
+| `update_serviceaccounts` | `update_serviceaccounts.yml` | Create ServiceAccounts and token secrets |
+| `update_role_bindings` | `update_role_bindings.yml` | Create/delete RoleBindings (Kyverno and native) |
+
+To skip a phase: `-e update_kubeconfigs=false`.
+
+## Required Variables
+
+| Variable | Type | Description |
+|---|---|---|
+| `kubeconfig` | string | Path to the admin kubeconfig used to authenticate with the cluster |
+| `present_users` | list | List of users whose service accounts, tokens, and bindings to manage |
+| `kubernetes_roles` | list | List of ClusterRole definitions to reconcile |
+| `permissions` | dict | Maps user keys to their Kubernetes permission configs |
+
+## Variable Templates
+
+### `kubernetes_roles`
+
+```yaml
+kubernetes_roles:
+  - name: "cluster-reader"
+    hosts: "cluster-a:cluster-b"
+    labels:
+      team: "platform"
+    rules:
+      - apiGroups: [""]
+        resources: ["pods"]
+        verbs: ["get", "list", "watch"]
+```
+
+### `permissions`
+
+```yaml
+permissions:
+  my_user:
+    kubernetes:
+      - hosts: "cluster-a"
+        role: "cluster-reader"
+        namespaces: ["default", "app"]        # Optional — triggers Kyverno ClusterPolicy
+        namespace_excludes: ["kube-system"]    # Optional
+```
+
+### `present_users`
+
+```yaml
+present_users:
+  - name: "my_user"
+    serviceaccount_name: "my-user-sa"           # Optional, defaults to `name`
+    permissions: "{{ permissions.my_user }}"
+```
+
+## Optional Variables
+
+| Variable | Type | Default | Description |
+|---|---|---|---|
+| `proxy_url` | string | *unset* | Proxy URL for cluster access |
+| `proxy_headers` | dict | *unset* | Extra proxy headers |
+| `generate_new_token` | bool | `false` | Force rotation of existing service account tokens |
+| `serviceaccount_namespace` | string | *required* | Namespace for the service account |
+
+## Example Usage
+
+```yaml
+---
+- name: Configure Kubernetes RBAC
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  roles:
+    - kubernetes_roles
+  vars:
+    kubeconfig: "/path/to/admin-kubeconfig"
+    serviceaccount_namespace: "default"
+    update_kubeconfigs: false
+    kubernetes_roles:
+      - name: "readonly"
+        hosts: "prod-cluster"
+        rules:
+          - apiGroups: [""]
+            resources: ["pods", "services"]
+            verbs: ["get", "list", "watch"]
+    present_users:
+      - name: "monitoring"
+        serviceaccount_name: "monitoring-sa"
+        permissions: "{{ permissions.monitoring }}"
+    permissions:
+      monitoring:
+        kubernetes:
+          - hosts: "prod-cluster"
+            role: "readonly"
+```

--- a/roles/kubernetes_roles/defaults/main.yml
+++ b/roles/kubernetes_roles/defaults/main.yml
@@ -1,4 +1,9 @@
 ---
+# Subtask toggles — set to false to skip a phase
+update_roles: true
+update_serviceaccounts: true
+update_role_bindings: true
+
 # Path to the kubeconfig file for cluster access
 kubeconfig: ""
 

--- a/roles/kubernetes_roles/tasks/main.yml
+++ b/roles/kubernetes_roles/tasks/main.yml
@@ -1,80 +1,12 @@
 ---
-- name: Create Kubernetes Cluster Roles
-  kubernetes.core.k8s:
-    state: present
-    kubeconfig: "{{ kubeconfig }}"
-    proxy: "{{ proxy_url | default(omit, true) }}"
-    proxy_headers: "{{ proxy_headers | default(omit, true) }}"
-    definition:
-      kind: ClusterRole
-      apiVersion: rbac.authorization.k8s.io/v1
-      metadata:
-        name: "{{ item.name }}"
-        labels: "{{ item.labels | default(omit) }}"
-      rules: "{{ item.rules }}"
-  loop: "{{ kubernetes_roles }}"
-  loop_control:
-    label: "{{ item.name }}"
-  when: inventory_hostname in (lookup('inventory_hostnames', item.hosts) | default('', true)).split(',')
+- name: Update Kubernetes roles
+  import_tasks: update_roles.yml
+  when: update_roles
 
-- name: Remove Kubernetes Cluster Roles
-  kubernetes.core.k8s:
-    state: absent
-    api_version: rbac.authorization.k8s.io/v1
-    kind: ClusterRole
-    name: "{{ item.name }}"
-    kubeconfig: "{{ kubeconfig }}"
-    proxy: "{{ proxy_url | default(omit, true) }}"
-    proxy_headers: "{{ proxy_headers | default(omit, true) }}"
-  loop: "{{ kubernetes_roles }}"
-  loop_control:
-    label: "{{ item.name }}"
-  when: inventory_hostname not in (lookup('inventory_hostnames', item.hosts) | default('', true)).split(',')
+- name: Update service accounts and tokens
+  import_tasks: update_serviceaccounts.yml
+  when: update_serviceaccounts
 
-- name: Create Kyverno RoleBinding ClusterPolicy
-  loop: "{{ permissions | dict2items | subelements('value.kubernetes', skip_missing=True) }}"
-  kubernetes.core.k8s:
-    state: present
-    kubeconfig: "{{ kubeconfig }}"
-    proxy: "{{ proxy_url | default(omit, true) }}"
-    proxy_headers: "{{ proxy_headers | default(omit, true) }}"
-    definition: "{{ lookup('template', 'cluster-access-kyverno-rb.yml.j2') }}"
-  when:
-    - inventory_hostname in (lookup('inventory_hostnames', item.1.hosts) | default('', true)).split(',')
-    - item.1.namespaces | default([]) | length > 0
-
-- name: Delete surplus Kyverno RoleBinding ClusterPolicy
-  loop: "{{ permissions | dict2items | subelements('value.kubernetes', skip_missing=True) }}"
-  kubernetes.core.k8s:
-    state: absent
-    api_version: kyverno.io/v1
-    kind: ClusterPolicy
-    name: "add-{{ item.0.key | regex_replace('_', '-') }}-{{ item.1.role }}-rolebinding"
-    kubeconfig: "{{ kubeconfig }}"
-    proxy: "{{ proxy_url | default(omit, true) }}"
-    proxy_headers: "{{ proxy_headers | default(omit, true) }}"
-  when: inventory_hostname not in (lookup('inventory_hostnames', permissions[item.0.key].kubernetes | default([]) | selectattr("namespaces", "defined") | selectattr("role", "equalto", item.1.role) | map(attribute='hosts') | join(':')) | default('', true)).split(',')
-
-- name: Create ClusterRoleBindings
-  loop: "{{ permissions | dict2items | subelements('value.kubernetes', skip_missing=True) }}"
-  kubernetes.core.k8s:
-    state: present
-    kubeconfig: "{{ kubeconfig }}"
-    proxy: "{{ proxy_url | default(omit, true) }}"
-    proxy_headers: "{{ proxy_headers | default(omit, true) }}"
-    definition: "{{ lookup('template', 'cluster-access-crb.yml.j2') }}"
-  when:
-    - inventory_hostname in (lookup('inventory_hostnames', item.1.hosts) | default('', true)).split(',')
-    - item.1.namespaces | default([]) | length == 0
-
-- name: Delete surplus ClusterRoleBindings
-  loop: "{{ permissions | dict2items | subelements('value.kubernetes', skip_missing=True) }}"
-  kubernetes.core.k8s:
-    state: absent
-    api_version: rbac.authorization.k8s.io/v1
-    kind: ClusterRoleBinding
-    name: "{{ item.0.key | regex_replace('_', '-') }}-{{ item.1.role }}-clusterrolebinding"
-    kubeconfig: "{{ kubeconfig }}"
-    proxy: "{{ proxy_url | default(omit, true) }}"
-    proxy_headers: "{{ proxy_headers | default(omit, true) }}"
-  when: inventory_hostname not in (lookup('inventory_hostnames', permissions[item.0.key].kubernetes | default([]) | selectattr("namespaces", "undefined") | selectattr("role", "equalto", item.1.role) | map(attribute='hosts') | join(':')) | default('', true)).split(',')
+- name: Update role bindings
+  import_tasks: update_role_bindings.yml
+  when: update_role_bindings

--- a/roles/kubernetes_roles/tasks/update_role_bindings.yml
+++ b/roles/kubernetes_roles/tasks/update_role_bindings.yml
@@ -1,0 +1,47 @@
+- name: Create Kyverno RoleBinding ClusterPolicy
+  loop: "{{ permissions | dict2items | subelements('value.kubernetes', skip_missing=True) }}"
+  kubernetes.core.k8s:
+    state: present
+    kubeconfig: "{{ kubeconfig }}"
+    proxy: "{{ proxy_url | default(omit, true) }}"
+    proxy_headers: "{{ proxy_headers | default(omit, true) }}"
+    definition: "{{ lookup('template', 'cluster-access-kyverno-rb.yml.j2') }}"
+  when:
+    - inventory_hostname in (lookup('inventory_hostnames', item.1.hosts) | default('', true)).split(',')
+    - item.1.namespaces | default([]) | length > 0
+
+- name: Delete surplus Kyverno RoleBinding ClusterPolicy
+  loop: "{{ permissions | dict2items | subelements('value.kubernetes', skip_missing=True) }}"
+  kubernetes.core.k8s:
+    state: absent
+    api_version: kyverno.io/v1
+    kind: ClusterPolicy
+    name: "add-{{ item.0.key | regex_replace('_', '-') }}-{{ item.1.role }}-rolebinding"
+    kubeconfig: "{{ kubeconfig }}"
+    proxy: "{{ proxy_url | default(omit, true) }}"
+    proxy_headers: "{{ proxy_headers | default(omit, true) }}"
+  when: inventory_hostname not in (lookup('inventory_hostnames', permissions[item.0.key].kubernetes | default([]) | selectattr("namespaces", "defined") | selectattr("role", "equalto", item.1.role) | map(attribute='hosts') | join(':')) | default('', true)).split(',')
+
+- name: Create ClusterRoleBindings
+  loop: "{{ permissions | dict2items | subelements('value.kubernetes', skip_missing=True) }}"
+  kubernetes.core.k8s:
+    state: present
+    kubeconfig: "{{ kubeconfig }}"
+    proxy: "{{ proxy_url | default(omit, true) }}"
+    proxy_headers: "{{ proxy_headers | default(omit, true) }}"
+    definition: "{{ lookup('template', 'cluster-access-crb.yml.j2') }}"
+  when:
+    - inventory_hostname in (lookup('inventory_hostnames', item.1.hosts) | default('', true)).split(',')
+    - item.1.namespaces | default([]) | length == 0
+
+- name: Delete surplus ClusterRoleBindings
+  loop: "{{ permissions | dict2items | subelements('value.kubernetes', skip_missing=True) }}"
+  kubernetes.core.k8s:
+    state: absent
+    api_version: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    name: "{{ item.0.key | regex_replace('_', '-') }}-{{ item.1.role }}-clusterrolebinding"
+    kubeconfig: "{{ kubeconfig }}"
+    proxy: "{{ proxy_url | default(omit, true) }}"
+    proxy_headers: "{{ proxy_headers | default(omit, true) }}"
+  when: inventory_hostname not in (lookup('inventory_hostnames', permissions[item.0.key].kubernetes | default([]) | selectattr("namespaces", "undefined") | selectattr("role", "equalto", item.1.role) | map(attribute='hosts') | join(':')) | default('', true)).split(',')

--- a/roles/kubernetes_roles/tasks/update_roles.yml
+++ b/roles/kubernetes_roles/tasks/update_roles.yml
@@ -1,0 +1,31 @@
+- name: Create Kubernetes Cluster Roles
+  kubernetes.core.k8s:
+    state: present
+    kubeconfig: "{{ kubeconfig }}"
+    proxy: "{{ proxy_url | default(omit, true) }}"
+    proxy_headers: "{{ proxy_headers | default(omit, true) }}"
+    definition:
+      kind: ClusterRole
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: "{{ item.name }}"
+        labels: "{{ item.labels | default(omit) }}"
+      rules: "{{ item.rules }}"
+  loop: "{{ kubernetes_roles }}"
+  loop_control:
+    label: "{{ item.name }}"
+  when: inventory_hostname in (lookup('inventory_hostnames', item.hosts) | default('', true)).split(',')
+
+- name: Remove Kubernetes Cluster Roles
+  kubernetes.core.k8s:
+    state: absent
+    api_version: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    name: "{{ item.name }}"
+    kubeconfig: "{{ kubeconfig }}"
+    proxy: "{{ proxy_url | default(omit, true) }}"
+    proxy_headers: "{{ proxy_headers | default(omit, true) }}"
+  loop: "{{ kubernetes_roles }}"
+  loop_control:
+    label: "{{ item.name }}"
+  when: inventory_hostname not in (lookup('inventory_hostnames', item.hosts) | default('', true)).split(',')

--- a/roles/kubernetes_roles/tasks/update_serviceaccounts.yml
+++ b/roles/kubernetes_roles/tasks/update_serviceaccounts.yml
@@ -1,0 +1,73 @@
+---
+- name: Create service accounts and tokens
+  vars:
+    serviceaccount_name: "{{ item.0.serviceaccount_name | default(item.0.name, true) }}"
+    serviceaccount_namespace: "{{ item.1.namespace | default('default', true) }}"
+    generate_new_token: "{{ item.0.name in (regenerate_users | default([])) }}"
+  loop: "{{ present_users | subelements('permissions.kubernetes', skip_missing=True) }}"
+  loop_control:
+    label: "{{ item.0.name }}-{{ item.1.hosts }}-{{ item.1.role }}"
+  when: inventory_hostname in (lookup('inventory_hostnames', item.1.hosts) | default('', true)).split(',')
+  block:
+    - name: Create ServiceAccount {{ serviceaccount_name }} if not present
+      kubernetes.core.k8s:
+        state: present
+        kubeconfig: "{{ kubeconfig }}"
+        proxy: "{{ proxy_url | default(omit, true) }}"
+        proxy_headers: "{{ proxy_headers | default(omit, true) }}"
+        wait: yes
+        definition:
+          kind: ServiceAccount
+          apiVersion: v1
+          metadata:
+            name: "{{ serviceaccount_name }}"
+            namespace: "{{ serviceaccount_namespace }}"
+          secrets:
+            - name: "{{ serviceaccount_name }}-token"
+      register: serviceaccount
+      retries: 2
+      delay: 10
+      tags: serviceaccount
+
+    - name: Create the Secret that entails the token for {{ serviceaccount_name }}
+      kubernetes.core.k8s:
+        state: present
+        force: "{{ generate_new_token }}"
+        kubeconfig: "{{ kubeconfig }}"
+        proxy: "{{ proxy_url | default(omit, true) }}"
+        proxy_headers: "{{ proxy_headers | default(omit, true) }}"
+        definition:
+          apiVersion: v1
+          kind: Secret
+          metadata:
+            name: "{{ serviceaccount_name }}-token"
+            namespace: "{{ serviceaccount_namespace }}"
+            annotations:
+              kubernetes.io/service-account.name: "{{ serviceaccount_name }}"
+          type: kubernetes.io/service-account-token
+      register: tokencreation
+      retries: 2
+      delay: 10
+      tags: serviceaccount
+
+    - name: Get tokens for {{ serviceaccount_name }}
+      kubernetes.core.k8s:
+        state: present
+        kubeconfig: "{{ kubeconfig }}"
+        proxy: "{{ proxy_url | default(omit, true) }}"
+        proxy_headers: "{{ proxy_headers | default(omit, true) }}"
+        definition:
+          kind: Secret
+          apiVersion: v1
+          metadata:
+            name: "{{ serviceaccount.result.secrets[0].name }}"
+            namespace: "{{ serviceaccount_namespace }}"
+      register: serviceaccount_token
+      retries: 2
+      delay: 10
+      tags: serviceaccount
+
+    - name: "Check that the values registered in a loop didn't get mixed up ({{ serviceaccount_name }})"
+      debug:
+        msg: ""
+      failed_when: not ansible_check_mode and serviceaccount_token.result.metadata.annotations['kubernetes.io/service-account.name'] != serviceaccount_name


### PR DESCRIPTION
# Description
Adjust role to also create service accounts and have these as disjoint subtasks that can be triggered independently.
Only the kubeconfig generation now remains in the logic of the taskfile, which needs to rmain private and was refactored to this specific use.

<!--
  This is a template to add as many information as possible to the PR, to help reviewer and as a checklist for you. Points to remember are set in the comments, please read and keep them in mind:

    - Code should be self-explanatory and share your knowledge with others
    - Document code that is not self-explanatory
    - Think about bugs and keep security in mind
    - Leave the code cleaner than you found it. Remove unnecessary lines. Listen to the linter.
-->

## Links to Tickets or other PRs

<!--
Base links to copy
- https://github.com/dbildungsplattform/????/pull/????
- https://ticketsystem.dbildungscloud.de/browse/DBP-????

-->

## Notes

<!--
You may want to provide additional information:
    - References
    - Rollout
    - Structure/Design
    - Repercussions
-->


## Approval for review

- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.