### PR TITLE
fix(onepassword)!: DBP-2205 Fix onepassword role, add namespace variable

### DIFF
--- a/roles/onepassword/defaults/main.yml
+++ b/roles/onepassword/defaults/main.yml
@@ -3,3 +3,4 @@
 image_pull_token_enabled: true
 ## image_pull_token_secret secret value is added via playbook on deployment, secret needs to be base64 encoded.
 # image_pull_token_secret:
+onepassword_connector_namespace: default

--- a/roles/onepassword/tasks/main.yml
+++ b/roles/onepassword/tasks/main.yml
@@ -15,7 +15,7 @@
 
 # The onepassword credentials json file is used by the connector to connect to central 1password service
 # See https://docs.ansible.com/ansible/latest/collections/kubernetes/core/k8s_module.html
-- name: Create onepassword credentials secret
+- name: Create onepassword Connector credentials secret
   kubernetes.core.k8s:
     state: present
     kubeconfig: "{{ kubeconfig }}"
@@ -27,7 +27,7 @@
       type: Opaque
       metadata:
         name: "{{ onepassword_connector_credentials_name }}"
-        namespace: default
+        namespace: "{{ onepassword_connector_namespace }}"
       data:
         1password-credentials.json: "{{ onepassword_connector_credentials_json | b64encode | b64encode }}"
 
@@ -43,14 +43,14 @@
       type: Opaque
       metadata:
         name: "{{ image_pull_secrets_name }}"
-        namespace: default
+        namespace: "{{ onepassword_connector_namespace }}"
       data:
         .dockerconfigjson: "{{ image_pull_token_secret }}"
   when: image_pull_token_enabled
 
 # The onepassword token is used by the operator to retrieve the secrets from the connector
 # See https://docs.ansible.com/ansible/latest/collections/kubernetes/core/k8s_module.html
-- name: Create onepassword servicecenter token secret
+- name: Create onepassword token secret
   kubernetes.core.k8s:
     state: present
     kubeconfig: "{{ kubeconfig }}"
@@ -62,33 +62,10 @@
       type: Opaque
       metadata:
         name: "{{ onepassword_connector_token_name }}"
-        namespace: default
+        namespace: "{{ onepassword_connector_namespace }}"
       data:
         token: "{{ onepassword_connector_token_value | b64encode}}"
-  when: stage not in ["prod", "staging"] or "schulcloud" not in group_names
-
-# This clusterrolebinding is used in the dev environment to grant access for the 1password operator to all namespaces
-# See https://docs.ansible.com/ansible/latest/collections/kubernetes/core/k8s_module.html
-- name: Create onepassword ClusterRoleBinding
-  kubernetes.core.k8s:
-    state: present
-    kubeconfig: "{{ kubeconfig }}"
-    proxy: "{{ proxy_url | default(omit, true) }}"
-    proxy_headers: "{{ proxy_headers | default(omit, true) }}"
-    definition:
-      kind: ClusterRoleBinding
-      apiVersion: rbac.authorization.k8s.io/v1
-      metadata:
-        name: onepassword-connect-operator-default
-      subjects:
-        - kind: ServiceAccount
-          name: onepassword-connect-operator
-          namespace: default
-      roleRef:
-        kind: ClusterRole
-        name: onepassword-connect-operator
-        apiGroup: rbac.authorization.k8s.io
-  when: stage not in ["prod", "staging"] or "schulcloud" not in group_names
+  when: onepassword_connector_values.operator.create | default(true)
 
 # See https://docs.ansible.com/ansible/latest/collections/kubernetes/core/helm_module.html
 - name: Install 1password connector and operator
@@ -97,7 +74,7 @@
     chart_ref: 1password/connect
     chart_version: "{{ onepassword_connector_chart_version }}"
     kubeconfig: "{{ kubeconfig }}"
-    release_namespace: default
+    release_namespace: "{{ onepassword_connector_namespace }}"
     update_repo_cache: true
     values:
       "{{ onepassword_connector_values }}"


### PR DESCRIPTION
# Description
The "Create onepassword ClusterRoleBinding" task is probably a workaround from a long time ago but is not actually needed as the 1Password connect Helm chart will create the required Roles and Bindings as long as operator.create is set to true, if operator.watchNamespace is an empty string or list, a ClusterRoleBinding is created, if it is a list a RoleBinding is created for each namespace. As long as operator.roleBinding.create or operator.clusterRoleBinding.create are set to true this is not a breaking change. Afterwards, the leftover ClusterRoleBindings will need to be cleaned up
<!--
  This is a template to add as many information as possible to the PR, to help reviewer and as a checklist for you. Points to remember are set in the comments, please read and keep them in mind:

    - Code should be self-explanatory and share your knowledge with others
    - Document code that is not self-explanatory
    - Think about bugs and keep security in mind
    - Leave the code cleaner than you found it. Remove unnecessary lines. Listen to the linter.
-->

## Links to Tickets or other PRs

<!--
Base links to copy
- https://github.com/dbildungsplattform/????/pull/????
- https://ticketsystem.dbildungscloud.de/browse/DBP-????

-->

## Notes

<!--
You may want to provide additional information:
    - References
    - Rollout
    - Structure/Design
    - Repercussions
-->


## Approval for review

- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.