### PR TITLE
fix(onepassword): DOPS-928 add correct credentials handling for chart => 2.3.0

### DIFF
--- a/roles/onepassword/tasks/main.yml
+++ b/roles/onepassword/tasks/main.yml
@@ -29,7 +29,7 @@
         name: "{{ onepassword_connector_credentials_name }}"
         namespace: default
       data:
-        1password-credentials.json: "{{ onepassword_connector_credentials_json | b64encode | b64encode }}"
+        1password-credentials.json: "{{ _onepassword_connector_credentials_json_encoded }}"
 
 - name: Create Image pull secret token
   kubernetes.core.k8s:
@@ -66,6 +66,9 @@
       data:
         token: "{{ onepassword_connector_token_value | b64encode}}"
   when: stage not in ["prod", "staging"] or "schulcloud" not in group_names
+
+- debug:
+    var: _onepassword_connector_credentials_json_encoded
 
 # This clusterrolebinding is used in the dev environment to grant access for the 1password operator to all namespaces
 # See https://docs.ansible.com/ansible/latest/collections/kubernetes/core/k8s_module.html

--- a/roles/onepassword/tasks/main.yml
+++ b/roles/onepassword/tasks/main.yml
@@ -13,9 +13,6 @@
   check_mode: false
   changed_when: false
 
-- debug:
-    var: _onepassword_connector_credentials_json_encoded
-
 # The onepassword credentials json file is used by the connector to connect to central 1password service
 # See https://docs.ansible.com/ansible/latest/collections/kubernetes/core/k8s_module.html
 - name: Create onepassword credentials secret

--- a/roles/onepassword/tasks/main.yml
+++ b/roles/onepassword/tasks/main.yml
@@ -13,6 +13,9 @@
   check_mode: false
   changed_when: false
 
+- debug:
+    var: _onepassword_connector_credentials_json_encoded
+
 # The onepassword credentials json file is used by the connector to connect to central 1password service
 # See https://docs.ansible.com/ansible/latest/collections/kubernetes/core/k8s_module.html
 - name: Create onepassword credentials secret
@@ -66,9 +69,6 @@
       data:
         token: "{{ onepassword_connector_token_value | b64encode}}"
   when: stage not in ["prod", "staging"] or "schulcloud" not in group_names
-
-- debug:
-    var: _onepassword_connector_credentials_json_encoded
 
 # This clusterrolebinding is used in the dev environment to grant access for the 1password operator to all namespaces
 # See https://docs.ansible.com/ansible/latest/collections/kubernetes/core/k8s_module.html

--- a/roles/onepassword/vars/main.yml
+++ b/roles/onepassword/vars/main.yml
@@ -1,8 +1,8 @@
 ---
 # chart 2.3.0 has a breaking change that changes the way credentials are handled 
-_onepassword_connector_credentials_json_encoded: >-
-  {% if onepassword_connector_chart_version is version('2.3.0', '>=') %}
+_onepassword_connector_credentials_json_encoded: |-
+  {%- if onepassword_connector_chart_version is version('2.3.0', '>=') %}
   {{ onepassword_connector_credentials_json | b64encode }}
-  {% else %}
+  {%- else %}
   {{ onepassword_connector_credentials_json | b64encode | b64encode }}
-  {% endif %}
+  {%- endif %}

--- a/roles/onepassword/vars/main.yml
+++ b/roles/onepassword/vars/main.yml
@@ -1,0 +1,8 @@
+---
+# chart 2.3.0 has a breaking change that changes the way credentials are handled 
+_onepassword_connector_credentials_json_encoded: >-
+  {% if onepassword_connector_chart_version is version('2.3.0', '>=') %}
+  {{ onepassword_connector_credentials_json | b64encode }}
+  {% else %}
+  {{ onepassword_connector_credentials_json | b64encode | b64encode }}
+  {% endif %}


### PR DESCRIPTION
1PW had a breaking change regarding the encoding of the main secret, this fixes it.

See https://github.com/1Password/connect-helm-charts/releases/tag/connect-2.3.0
